### PR TITLE
Deprecate fitsio, fix #114

### DIFF
--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -314,7 +314,7 @@ class BaseScanner:
     # @staticmethod
     def calculate_abs_mag(self, mag: float, redshift: float) -> float:
         """ """
-        luminosity_distance = cosmo.luminosity_distance(redshift).value * 10**6
+        luminosity_distance = cosmo.luminosity_distance(redshift).value * 10 ** 6
         abs_mag = mag - 5 * (np.log10(luminosity_distance) - 1)
 
         return abs_mag

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -314,7 +314,7 @@ class BaseScanner:
     # @staticmethod
     def calculate_abs_mag(self, mag: float, redshift: float) -> float:
         """ """
-        luminosity_distance = cosmo.luminosity_distance(redshift).value * 10 ** 6
+        luminosity_distance = cosmo.luminosity_distance(redshift).value * 10**6
         abs_mag = mag - 5 * (np.log10(luminosity_distance) - 1)
 
         return abs_mag

--- a/nuztf/observations.py
+++ b/nuztf/observations.py
@@ -2,14 +2,10 @@ import glob
 
 import pyvo.dal
 import time
-import os
-import numpy as np
-from ztfquery.io import LOCALSOURCE
 from nuztf import credentials
 from pyvo.auth import securitymethods, authsession
 import requests
 import pandas as pd
-from astropy.time import Time
 import logging
 from glob import glob
 import backoff

--- a/nuztf/skymap_scanner.py
+++ b/nuztf/skymap_scanner.py
@@ -584,8 +584,8 @@ class SkymapScanner(BaseScanner):
 
             for x in hdul:
                 if data is None:
-                    if hasattr(x, "data"):
-                        data = x.data
+                    if x.data is not None:
+                        data = np.array(x.data)
 
                 if "DISTMEAN" in x.header:
                     dist = x.header["DISTMEAN"]

--- a/nuztf/skymap_scanner.py
+++ b/nuztf/skymap_scanner.py
@@ -3,16 +3,15 @@
 
 import os
 import wget
-import logging
 import time
 import json
+import logging
 
 from tqdm import tqdm
 import requests
 from numpy.lib.recfunctions import append_fields
 import lxml.etree
 from lxml import html
-import fitsio
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -20,6 +19,7 @@ from astropy_healpix import HEALPix
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 from astropy.time import Time
+from astropy.io import fits
 
 import healpy as hp
 from ztfquery.io import LOCALSOURCE
@@ -573,21 +573,31 @@ class SkymapScanner(BaseScanner):
 
         self.logger.info(f"Reading file: {self.skymap_path}")
 
-        data, h = fitsio.read(self.skymap_path, header=True)
+        with fits.open(self.skymap_path) as hdul:
+            data = None
+            h = hdul[0].header
 
-        if "DISTMEAN" not in h:
             dist = None
-        else:
-            dist = h["DISTMEAN"]
-        if "DISTSTD" not in h:
             dist_unc = None
-        else:
-            dist_unc = h["DISTSTD"]
+            t_obs = None
+            ordering = None
 
-        if "DATE-OBS" not in h:
-            t_obs = fitsio.read_header(self.skymap_path)["DATE-OBS"]
-        else:
-            t_obs = h["DATE-OBS"]
+            for x in hdul:
+                if data is None:
+                    if hasattr(x, "data"):
+                        data = x.data
+
+                if "DISTMEAN" in x.header:
+                    dist = x.header["DISTMEAN"]
+
+                if "DISTSTD" in x.header:
+                    dist_unc = x.header["DISTSTD"]
+
+                if "DATE-OBS" in x.header:
+                    t_obs = x.header["DATE-OBS"]
+
+                if "ORDERING" in x.header:
+                    ordering = x.header["ORDERING"]
 
         if "PROB" in data.dtype.names:
             key = "PROB"
@@ -605,12 +615,11 @@ class SkymapScanner(BaseScanner):
                 f"Found the following keys: {data.dtype.names}"
             )
 
-        if h["ORDERING"] == "NUNIQ":
+        if ordering == "NUNIQ":
             self.logger.info("Rasterising skymap to convert to nested format")
             data = data[list(["UNIQ", key])]
             probs = rasterize(data, order=7)
             data = np.array(probs, dtype=np.dtype([("PROB", float)]))
-            h["ORDERING"] = "NESTED"
 
         if not isinstance(data["PROB"][0], float):
             self.logger.info("Flattening skymap")
@@ -624,9 +633,16 @@ class SkymapScanner(BaseScanner):
 
         self.logger.info(f"Summed probability is {100. * np.sum(data['PROB']):.1f}%")
 
-        if h["ORDERING"] == "RING":
+        if ordering == "RING":
             data["PROB"] = hp.pixelfunc.reorder(data["PROB"], inp="RING", out="NESTED")
+
+        if ordering is not None:
             h["ORDERING"] = "NESTED"
+        else:
+            raise Exception(
+                f"Error parsing fits file, no ordering found. "
+                f"Please enter the ordewring (NESTED/RING/NUNIQ)"
+            )
 
         hpm = HEALPix(nside=h["NSIDE"], order=h["ORDERING"], frame="icrs")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ astroquery==0.4.4
 backoff==1.11.1
 black==22.1.0
 coveralls == 3.3.1
-fitsio==1.1.6
 geopandas==0.10.2
 gwemopt==0.0.73
 healpy==1.15.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setuptools.setup(
         "black == 22.1.0",
         "backoff == 1.11.1",
         "coveralls == 3.3.1",
-        "fitsio == 1.1.6",
         "geopandas == 0.10.2",
         "gwemopt == 0.0.73",
         "healpy == 1.15.0",


### PR DESCRIPTION
This PR would remove the single use of `fitsio` (in `skymap_scanner.py`), and remove the package from `requirements.txt`/`setup.py`. Instead, fits files would be opened with `astropy`. Some modifications of the header-checking logic of `skymap_scanner.py` were implemented. With this PR, we close #114 .