### PR TITLE
Add missing '=' in requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ mocpy==0.11.0
 numpy==1.22.0
 pandas==1.3.5
 pre_commit == 2.17.0
-python-ligo-lw=1.7.1
+python-ligo-lw==1.7.1
 pyvo==1.1
 requests==2.26.0
 seaborn == 0.11.2


### PR DESCRIPTION
Typo in requirements.txt from #119, led to disabling dependabot. Will now fix, I hope.