### PR TITLE
Make GCN draft even if info is missing

### DIFF
--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -356,6 +356,19 @@ class BaseScanner:
 
         return abs_mag
 
+    def get_candidates_lines(self):
+        if len(self.cache) > 0:
+            s = (
+                "We are left with the following high-significance transient "
+                "candidates by our pipeline, all lying within the "
+                f"{100 * self.prob_threshold}% localization of the skymap.\n\n{self.parse_candidates()}"
+            )
+        else:
+            s = "\n\nNo candidate counterparts were detected."
+
+        return s
+
+
     def parse_candidates(self):
 
         table = (
@@ -423,9 +436,8 @@ class BaseScanner:
             "The images were processed in real-time through the ZTF reduction and image subtraction pipelines at IPAC to search for potential counterparts (Masci et al. 2019). "
             "AMPEL (Nordin et al. 2019, Stein et al. 2021) was used to search the alerts database for candidates. "
             "We reject stellar sources (Tachibana and Miller 2018) and moving objects, and "
-            f"apply machine learning algorithms (Mahabal et al. 2019) {self.remove_variability_line()}. We are left with the following high-significance transient "
-            "candidates by our pipeline, all lying within the "
-            f"{100 * self.prob_threshold}% localization of the skymap.\n\n{self.parse_candidates()} \n\n"
+            f"apply machine learning algorithms (Mahabal et al. 2019) {self.remove_variability_line()}. "
+            f"{self.get_candidates_lines()} \n\n"
         )
 
         if self.dist:

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -759,6 +759,10 @@ class BaseScanner:
             data = data[first_det_mask]
             obs_times = obs_times[first_det_mask]
 
+        if len(obs_times) == 0:
+            self.logger.warning("No observations found for this event.")
+            return None
+
         self.logger.info(f"Most recent observation found is {obs_times[-1]}")
         self.logger.info("Unpacking observations")
 
@@ -890,26 +894,32 @@ class BaseScanner:
     ):
         """ """
 
-        (
-            double_in_plane_pixels,
-            double_in_plane_probs,
-            single_in_plane_pixels,
-            single_in_plane_prob,
-            veto_pixels,
-            plane_pixels,
-            plane_probs,
-            times,
-            double_no_plane_prob,
-            double_no_plane_pixels,
-            single_no_plane_prob,
-            single_no_plane_pixels,
-            overlapping_fields,
-        ) = self.calculate_overlap_with_observations(
+        overlap_res = self.calculate_overlap_with_observations(
             fields=fields,
             pid=pid,
             first_det_window_days=first_det_window_days,
             min_sep=min_sep,
         )
+
+        if overlap_res is None:
+            self.logger.warning("Not plotting overlap with observations.")
+            return
+        else:
+            (
+                double_in_plane_pixels,
+                double_in_plane_probs,
+                single_in_plane_pixels,
+                single_in_plane_prob,
+                veto_pixels,
+                plane_pixels,
+                plane_probs,
+                times,
+                double_no_plane_prob,
+                double_no_plane_pixels,
+                single_no_plane_prob,
+                single_no_plane_pixels,
+                overlapping_fields,
+            ) = overlap_res
 
         fig = plt.figure()
         plt.subplot(projection="aitoff")

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -152,7 +152,9 @@ class BaseScanner:
 
     def get_overlap_line(self):
         """ """
-        if (self.overlap_prob is not None) and (self.double_extragalactic_area is not None):
+        if (self.overlap_prob is not None) and (
+            self.double_extragalactic_area is not None
+        ):
             return (
                 f"We covered {self.overlap_prob:.1f}% ({self.double_extragalactic_area:.1f} sq deg) "
                 f"of the reported localization region. "
@@ -368,7 +370,6 @@ class BaseScanner:
 
         return s
 
-
     def parse_candidates(self):
 
         table = (
@@ -420,7 +421,11 @@ class BaseScanner:
     def draft_gcn(self):
 
         if self.first_obs is None:
-            self.first_obs = Time(input("What was the first observation date? (YYYY-MM-DD HH:MM:SS [UTC])"))
+            self.first_obs = Time(
+                input(
+                    "What was the first observation date? (YYYY-MM-DD HH:MM:SS [UTC])"
+                )
+            )
 
         first_obs_dt = self.first_obs.datetime
         pretty_date = first_obs_dt.strftime("%Y-%m-%d")

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -152,11 +152,15 @@ class BaseScanner:
 
     def get_overlap_line(self):
         """ """
-        return (
-            f"We covered {self.overlap_prob:.1f}% ({self.double_extragalactic_area:.1f} sq deg) "
-            f"of the reported localization region. "
-            "This estimate accounts for chip gaps. "
-        )
+        if (self.overlap_prob is not None) and (self.double_extragalactic_area is not None):
+            return (
+                f"We covered {self.overlap_prob:.1f}% ({self.double_extragalactic_area:.1f} sq deg) "
+                f"of the reported localization region. "
+                "This estimate accounts for chip gaps. "
+            )
+        else:
+            self.logger.warning("No overlap line added!")
+            return ""
 
     def filter_ampel(self, res):
         self.logger.debug("Running AMPEL filter")

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -402,10 +402,10 @@ class BaseScanner:
 
     def draft_gcn(self):
 
-        first_obs_dt = (
-            self.first_obs.datetime if self.first_obs
-            else Time(input("What was the first observation date? (YYYY-MM-DD HH:MM:SS [UTC])"))
-        )
+        if self.first_obs is None:
+            self.first_obs = Time(input("What was the first observation date? (YYYY-MM-DD HH:MM:SS [UTC])"))
+
+        first_obs_dt = self.first_obs.datetime
         pretty_date = first_obs_dt.strftime("%Y-%m-%d")
         pretty_time = first_obs_dt.strftime("%H:%M")
 

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -694,7 +694,7 @@ class BaseScanner:
             text += "\n"
 
         if len(text) > 0:
-            text = f"\n\nAmongst our candidates, {text}\n\n"
+            text = f"Amongst our candidates, \n\n{text}\n\n"
 
         return text
 

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -402,7 +402,10 @@ class BaseScanner:
 
     def draft_gcn(self):
 
-        first_obs_dt = self.first_obs.datetime
+        first_obs_dt = (
+            self.first_obs.datetime if self.first_obs
+            else Time(input("What was the first observation date? (YYYY-MM-DD HH:MM:SS [UTC])"))
+        )
         pretty_date = first_obs_dt.strftime("%Y-%m-%d")
         pretty_time = first_obs_dt.strftime("%H:%M")
 

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -449,7 +449,7 @@ class BaseScanner:
         else:
             pass
 
-        text += f"Amongst our candidates, \n\n{self.text_summary()}\n\n"
+        text += self.text_summary()
 
         text += (
             "ZTF and GROWTH are worldwide collaborations comprising Caltech, USA; IPAC, USA; WIS, Israel; OKC, Sweden; JSI/UMd, USA; DESY, Germany; TANGO, Taiwan; UW Milwaukee, USA; LANL, USA; TCD, Ireland; IN2P3, France.\n\n"
@@ -687,6 +687,9 @@ class BaseScanner:
             xmatch_info = get_cross_match_info(raw=res, logger=self.logger)
             text += xmatch_info
             text += "\n"
+
+        if len(text) > 0:
+            text = f"\n\nAmongst our candidates, {text}\n\n"
 
         return text
 


### PR DESCRIPTION
Make `draft_gcn()` run even if info like the observation log is missing and raise warnings.
For `IC230112A` for example, `nu.plot_overlap_with_observations(first_det_window_days=3.)` will give 

```
INFO:nuztf.observations:Getting observation logs from skyvision.
/Users/jannisnecker/opt/miniconda3/envs/nuztf/lib/python3.10/site-packages/ztfquery/skyvision.py:240: UserWarning: No observing log for 2023-01-12
  warnings.warn(f"No observing log for {date}")
/Users/jannisnecker/opt/miniconda3/envs/nuztf/lib/python3.10/site-packages/ztfquery/skyvision.py:240: UserWarning: No observing log for 2023-01-13
  warnings.warn(f"No observing log for {date}")
/Users/jannisnecker/opt/miniconda3/envs/nuztf/lib/python3.10/site-packages/ztfquery/skyvision.py:240: UserWarning: No observing log for 2023-01-14
  warnings.warn(f"No observing log for {date}")
/Users/jannisnecker/opt/miniconda3/envs/nuztf/lib/python3.10/site-packages/ztfquery/skyvision.py:240: UserWarning: No observing log for 2023-01-15
  warnings.warn(f"No observing log for {date}")
WARNING:nuztf.base_scanner:No observations found for this event.
WARNING:nuztf.base_scanner:Not plotting overlap with observations.
```


and `nu.draft_gcn()`
```
WARNING:nuztf.base_scanner:No overlap line added!
```

with the resulting draft
```
Astronomer Name (Institute of Somewhere), ............. report,

On behalf of the Zwicky Transient Facility (ZTF) and Global Relay of Observatories Watching Transients Happen (GROWTH) collaborations: 

As part of the ZTF neutrino follow up program (Stein et al. 2022), we observed the localization region of the neutrino event IceCube-230112A (Massimiliano et. al, GCN 33161) with the Palomar 48-inch telescope, equipped with the 47 square degree ZTF camera (Bellm et al. 2019, Graham et al. 2019). We started observations in the g- and r-band beginning at 2023-01-13 02:43 UTC, approximately 20.0 hours after event time. Each exposure was 300s with a typical depth of 21.0 mag. 
 
The images were processed in real-time through the ZTF reduction and image subtraction pipelines at IPAC to search for potential counterparts (Masci et al. 2019). AMPEL (Nordin et al. 2019, Stein et al. 2021) was used to search the alerts database for candidates. We reject stellar sources (Tachibana and Miller 2018) and moving objects, and apply machine learning algorithms (Mahabal et al. 2019) . 

No candidate counterparts were detected. 

ZTF and GROWTH are worldwide collaborations comprising Caltech, USA; IPAC, USA; WIS, Israel; OKC, Sweden; JSI/UMd, USA; DESY, Germany; TANGO, Taiwan; UW Milwaukee, USA; LANL, USA; TCD, Ireland; IN2P3, France.

GROWTH acknowledges generous support of the NSF under PIRE Grant No 1545949.
Alert distribution service provided by DIRAC@UW (Patterson et al. 2019).
Alert database searches are done by AMPEL (Nordin et al. 2019).
Alert filtering is performed with the nuztf (Stein et al. 2021, https://github.com/desy-multimessenger/nuztf).
```