### PR TITLE
Clean __init__.py

### DIFF
--- a/nuztf/__init__.py
+++ b/nuztf/__init__.py
@@ -1,3 +1,1 @@
 import nuztf.credentials
-from nuztf.neutrino_scanner import NeutrinoScanner
-from nuztf.skymap_scanner import SkymapScanner

--- a/tests/test_neutrino_scanner.py
+++ b/tests/test_neutrino_scanner.py
@@ -5,10 +5,10 @@ import numpy as np
 from astropy.coordinates import Distance
 from astropy.time import Time
 
-from nuztf import NeutrinoScanner
 from nuztf.ampel_api import ampel_api_catalog
 from nuztf.base_scanner import cosmo
 from nuztf.cat_match import query_ned_for_z
+from nuztf.neutrino_scanner import NeutrinoScanner
 
 
 class TestNeutrinoScanner(unittest.TestCase):


### PR DESCRIPTION
This PR removes a couple of imports from the base nuztf code `__init__.py` fle. That might seem pointless, but it means that the gcn parsing can be imported without touching/importing any of the ampel-interfacing code. That is important because ampel needs pydantic v1, and winter api code needs pydantic v2. I hope Ampel will soon be bumped to use pydantic v2 as well.