### PR TITLE
`NeutrinoKafkaScanner` Bugfix: handle NaNs in skymaps

### DIFF
--- a/nuztf/ampel/urls.py
+++ b/nuztf/ampel/urls.py
@@ -1,4 +1,4 @@
-API_BASEURL = "https://ampel.zeuthen.desy.de"
+API_BASEURL = "https://ampel-ztf.zeuthen.desy.de"
 API_ZTF_ARCHIVE_URL = API_BASEURL + "/api/ztf/archive/v3"
 API_CATALOGMATCH_URL = API_BASEURL + "/api/catalogmatch"
 

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -21,8 +21,8 @@ from astropy.time import Time
 from matplotlib.backends.backend_pdf import PdfPages
 from tqdm import tqdm
 
-from nuztf.ampel.utils import merge_alerts
 from nuztf.ampel.urls import API_CATALOGMATCH_URL
+from nuztf.ampel.utils import merge_alerts
 from nuztf.api import ZTF_BACKEND, api_name, api_skymap
 from nuztf.cat_match import ampel_api_tns, get_cross_match_info, query_ned_for_z
 from nuztf.flatpix import get_nested_pix
@@ -69,7 +69,7 @@ class BaseScanner:
 
         if resource is None:
             resource = {
-                "ampel-ztf/catalogmatch":API_CATALOGMATCH_URL,
+                "ampel-ztf/catalogmatch": API_CATALOGMATCH_URL,
             }
 
         if logger is None:

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -22,6 +22,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 from tqdm import tqdm
 
 from nuztf.ampel.utils import merge_alerts
+from nuztf.ampel.urls import API_CATALOGMATCH_URL
 from nuztf.api import ZTF_BACKEND, api_name, api_skymap
 from nuztf.cat_match import ampel_api_tns, get_cross_match_info, query_ned_for_z
 from nuztf.flatpix import get_nested_pix
@@ -68,7 +69,7 @@ class BaseScanner:
 
         if resource is None:
             resource = {
-                "ampel-ztf/catalogmatch": "https://ampel.zeuthen.desy.de/api/catalogmatch/",
+                "ampel-ztf/catalogmatch":API_CATALOGMATCH_URL,
             }
 
         if logger is None:

--- a/nuztf/base_scanner.py
+++ b/nuztf/base_scanner.py
@@ -69,7 +69,7 @@ class BaseScanner:
 
         if resource is None:
             resource = {
-                "ampel-ztf/catalogmatch": API_CATALOGMATCH_URL,
+                "ampel-ztf/catalogmatch": API_CATALOGMATCH_URL + "/",
             }
 
         if logger is None:

--- a/nuztf/neutrino_kafka_scanner.py
+++ b/nuztf/neutrino_kafka_scanner.py
@@ -103,6 +103,10 @@ class NeutrinoKafkaScanner(NeutrinoScanner):
         else:
             skymap = self.skymap
 
+        # some skymap fits do not converge on every pixel
+        # to ignore them we assign 0 probability
+        skymap["PROB"][np.isnan(skymap["PROB"])] = 0
+
         # the map contains the probability per pixel so we need to convert
         # to cumulative probability contained within a contour
         credible_levels = find_greedy_credible_levels(skymap["PROB"])
@@ -161,9 +165,11 @@ def load_alert(nu_name: str) -> dict:
     if len(files) == 0:
         raise FileNotFoundError(f"No file found in {GCN_KAFKA_CACHE} for {nu_name}!")
     if len(files) > 1:
-        raise RuntimeError(
-            f"More than one file found in {GCN_KAFKA_CACHE} for {nu_name}!"
+        logger.info(
+            f"More than one file found in {GCN_KAFKA_CACHE} for {nu_name}! Using latest one"
         )
+        files = sorted(files, key=lambda p: p.stat().st_mtime, reverse=True)
+    logger.info(f"Loading {files[0]}")
     with open(GCN_KAFKA_CACHE / files[0], "r") as f:
         return json.load(f)
 


### PR DESCRIPTION
If there were NaNs in the probability skymap in the `NeutrinoKafkaScanner`, the code failed silently. The [`in_contour`](https://github.com/desy-multimessenger/nuztf/blob/542bd0e6f235f0d3512bdb6441f95059cc2af3ef/nuztf/neutrino_kafka_scanner.py#L133-L139) method returned NaNs, resulting in [`False` when checking if `in_contour(...)`](https://github.com/desy-multimessenger/nuztf/blob/542bd0e6f235f0d3512bdb6441f95059cc2af3ef/nuztf/neutrino_scanner.py#L181). 
Now the NaNs are set to zero.
I re-ran all candidate filtering for the follow-ups of IC260217A, IC260315A, and IC260504A to make sure this did not affect any results.